### PR TITLE
[DNAAPP-1654] add data-and-analytics-apps as codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# File ownership for DataDog/data-and-analytics-apps group
+* @DataDog/data-and-analytics-apps


### PR DESCRIPTION
### Motivation

Add codeowners to the repo so that Datadog can track who owns it

### Changes

- Add codeowners with the @DataDog/data-and-analytics-apps

### Testing

### Additional notes
