### PR TITLE
added freeze shortcuts

### DIFF
--- a/schema/plugin.json
+++ b/schema/plugin.json
@@ -16,5 +16,17 @@
     }
   },
   "additionalProperties": false,
-  "type": "object"
+  "type": "object",
+  "jupyter.lab.shortcuts": [
+    {
+      "command": "notebook:toggle-cell-freeze",
+      "keys": ["Accel E"],
+      "selector": ".jp-Notebook"
+    },
+    {
+      "command": "notebook:toggle-cell-read-only",
+      "keys": ["Accel G"],
+      "selector": ".jp-Notebook"
+    }
+  ]
 }

--- a/src/freeze.tsx
+++ b/src/freeze.tsx
@@ -79,6 +79,18 @@ function updateMetadata(state: CellState, cell: Cell<ICellModel>) {
   cell.update();
 }
 
+export function changeState(state: CellState, notebookPanel: NotebookPanel) {
+  const notebook = notebookPanel.content;
+  const currentCell = notebook.widgets[notebook.activeCellIndex];
+  if (currentCell) {
+    const currentState = getState(currentCell);
+    const newState: CellState = currentState === state ? 'normal' : state;
+    updateMetadata(newState, currentCell);
+    notebookPanel.update();
+  }
+}
+
+
 const FreezeComponent = (props: {
   // Taking a NotebookPanel rather than an INotebookTracker here simplifies the necessary state management
   // since we're always operating in the context of this particular notebook
@@ -91,19 +103,6 @@ const FreezeComponent = (props: {
    * @returns The rendered JSX element.
    */
 
-  function buttonCallback(state: CellState) {
-    /**
-     * Callback function for button clicks in the current cell
-     *
-     * @param state - The state to set the selected cell to.
-     */
-    let notebook = props.notebook.content;
-    notebook.selectedCells.forEach(cell => {
-      updateMetadata(state, cell);
-    });
-    props.notebook.update();
-  }
-
   return (
     <>
       <div title="Lift restrictions from selected cells">
@@ -111,7 +110,7 @@ const FreezeComponent = (props: {
           className="jp-ToolbarButtonComponent jp-mod-minimal jp-Button"
           aria-pressed="false"
           aria-disabled="false"
-          onClick={() => buttonCallback('normal')}
+          onClick={() => changeState('normal', props.notebook)}
         >
           <FaLockOpen />
         </button>
@@ -121,7 +120,7 @@ const FreezeComponent = (props: {
           className="jp-ToolbarButtonComponent jp-mod-minimal jp-Button"
           aria-pressed="false"
           aria-disabled="false"
-          onClick={() => buttonCallback('read_only')}
+          onClick={() => changeState('read_only', props.notebook)}
         >
           <FaLock />
         </button>
@@ -131,7 +130,7 @@ const FreezeComponent = (props: {
           className="jp-ToolbarButtonComponent jp-mod-minimal jp-Button"
           aria-pressed="false"
           aria-disabled="false"
-          onClick={() => buttonCallback('frozen')}
+          onClick={() => changeState('frozen', props.notebook)}
         >
           <FaAsterisk />
         </button>

--- a/src/freeze.tsx
+++ b/src/freeze.tsx
@@ -81,13 +81,12 @@ function updateMetadata(state: CellState, cell: Cell<ICellModel>) {
 
 export function changeState(state: CellState, notebookPanel: NotebookPanel) {
   const notebook = notebookPanel.content;
-  const currentCell = notebook.widgets[notebook.activeCellIndex];
-  if (currentCell) {
+  notebook.selectedCells.forEach(currentCell => {
     const currentState = getState(currentCell);
     const newState: CellState = currentState === state ? 'normal' : state;
     updateMetadata(newState, currentCell);
-    notebookPanel.update();
-  }
+  });
+  notebookPanel.update();
 }
 
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ import {
 import { ISettingRegistry } from '@jupyterlab/settingregistry';
 import { INotebookTracker } from '@jupyterlab/notebook';
 import { NotebookPanel } from '@jupyterlab/notebook';
-import { FreezeWidget } from './freeze';
+import { FreezeWidget, changeState } from './freeze';
 
 const PLUGIN_ID = 'jupyterlab_freeze:plugin';
 const FREEZE_KEY = '--jp-freeze-frozen-bg';
@@ -72,6 +72,30 @@ const plugin: JupyterFrontEndPlugin<void> = {
         });
       }
     );
+
+    // Add command for freezing/unfreezing cells for keyboard shortcut
+    app.commands.addCommand('notebook:toggle-cell-freeze', {
+      label: 'Freeze/Unfreeze Cell',
+      execute: () => {
+        const notebookPanel = notebookTracker.currentWidget;
+        if (notebookPanel) {
+          changeState('frozen', notebookPanel);
+        }
+      },
+      isEnabled: () => !!notebookTracker.currentWidget
+    });
+
+    // Add command for setting cells to read-only for keyboard shortcut
+    app.commands.addCommand('notebook:toggle-cell-read-only', {
+      label: 'Set Cell to Read-Only or Back to Editable',
+      execute: () => {
+        const notebookPanel = notebookTracker.currentWidget;
+        if (notebookPanel) {
+          changeState('read_only', notebookPanel);
+        }
+      },
+      isEnabled: () => !!notebookTracker.currentWidget
+    });
   }
 };
 


### PR DESCRIPTION
What:
- Solves https://github.com/DataDog/jupyterlab-freeze/issues/5
- Created keyboard shortcuts for jupyterlab freeze, read-only, and normal features for notebook cells.
Should also show up in settings like so and are user-editable:
<img width="869" alt="Screenshot 2024-11-18 at 10 57 03 AM" src="https://github.com/user-attachments/assets/25e84aee-12a0-436e-9cbe-01e92fcdc595">
<img width="869" alt="Screenshot 2024-11-18 at 10 57 09 AM" src="https://github.com/user-attachments/assets/9d12a6b6-b431-4e33-856b-41b0ad91f15e">

Test:
- check out to this branch and run the instructions [here](https://github.com/DataDog/jupyterlab-freeze?tab=readme-ov-file#contributing)
- spin up a notebook
- click on a cell and test out these mappings:
-> cmd + e => freeze/unfreeze
-> cmd + g => read-only/editable (id appreciate any better options here instead of 'g' for improved UX)
